### PR TITLE
fix(main.ts): Fix properties breaking when using simple quotes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -55,7 +55,7 @@ export default class InlineFMSync extends Plugin {
 			return value;
 		}
 		// console.log('wrapping' + value, `'${value}'`)
-		return `'${value}'`;
+		return `'${value.replaceAll("'", "''")}'`;
 	}
 
 	updateFrontmatterValue(editor: Editor, fieldName: string, newValue: string) {


### PR DESCRIPTION
Escape simple quotes by replacing them with two simple quotes.
Fixes ransurf/live-sync-inline-to-yaml#2